### PR TITLE
[Readme] Remove redundant check in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,8 @@ assert(arguments.count >= 1)
 arguments.removeAtIndex(0)
 
 if let verb = arguments.first {
-	if arguments.count > 0 {
-		// Remove the command name.
-		arguments.removeAtIndex(0)
-	}
+	// Remove the command name.
+	arguments.removeAtIndex(0)
 
 	if let result = commands.runCommand(verb, arguments: arguments) {
 		// Handle success or failure.


### PR DESCRIPTION
There is no code path, which allows to reach the removed wrapping if statement, so that the condition is false. Btw. what's wrong with the diff rendering here? First it wasn't able to render at all, now it is showing wrong indentation. :hushed: 
