### PR TITLE
Separate multi-line usage description with `newlineCharacterSet`.

### DIFF
--- a/Commandant/Errors.swift
+++ b/Commandant/Errors.swift
@@ -39,7 +39,7 @@ internal func informativeUsageError<T>(keyValueExample: String, option: Option<T
 		description += "]"
 	}
 
-	description += option.usage.componentsSeparatedByString("\n")
+	description += option.usage.componentsSeparatedByCharactersInSet(NSCharacterSet.newlineCharacterSet())
 		.reduce(""){ previous, value in
 			return previous + "\n\t" + value
 		}


### PR DESCRIPTION
*Related to #17*

Based off [this comment.](https://github.com/Carthage/Commandant/pull/17#discussion_r24301394)

[Apple’s documentation for `newlineCharacterSet`](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSCharacterSet_Class/index.html#//apple_ref/occ/clm/NSCharacterSet/newlineCharacterSet)