### PR TITLE
Move testing dependencies to private Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,2 @@
-github "Quick/Quick" == 0.2.0
-github "Quick/Nimble"
 github "Carthage/LlamaKit" == 0.1.1
 github "jspahrsummers/xcconfigs" >= 0.6

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,0 +1,2 @@
+github "Quick/Quick" == 0.2.0
+github "Quick/Nimble"


### PR DESCRIPTION
These aren't actually dependencies of Commandant, and are only used for 
testing. We shouldn't list them with the actual dependencies.