### PR TITLE
Parameterize CommandantError by a ClientError type

### DIFF
--- a/Commandant/ArgumentParser.swift
+++ b/Commandant/ArgumentParser.swift
@@ -100,7 +100,7 @@ public final class ArgumentParser {
 	///
 	/// If a value is found, the key and the value are both removed from the
 	/// list of arguments remaining to be parsed.
-	internal func consumeValueForKey(key: String) -> Result<String?, CommandantError> {
+	internal func consumeValueForKey(key: String) -> Result<String?, CommandantError<NoError>> {
 		let oldArguments = rawArguments
 		rawArguments.removeAll()
 

--- a/Commandant/Errors.swift
+++ b/Commandant/Errors.swift
@@ -7,21 +7,18 @@
 //
 
 import Foundation
+import LlamaKit
 
 /// Possible errors that can originate from Commandant.
-public enum CommandantError {
+///
+/// `ClientError` should be the type of error (if any) that can occur when
+/// running commands.
+public enum CommandantError<ClientError> {
 	/// An option was used incorrectly.
 	case UsageError(description: String)
 
-	/// Creates an NSError that represents the receiver.
-	public func toNSError() -> NSError {
-		let domain = "org.carthage.Commandant"
-
-		switch self {
-		case let .UsageError(description):
-			return NSError(domain: domain, code: 0, userInfo: [ NSLocalizedDescriptionKey: description ])
-		}
-	}
+	/// An error occurred while running a command.
+	case CommandError(Box<ClientError>)
 }
 
 extension CommandantError: Printable {
@@ -29,20 +26,26 @@ extension CommandantError: Printable {
 		switch self {
 		case let .UsageError(description):
 			return description
+
+		case let .CommandError(error):
+			return toString(error)
 		}
 	}
 }
 
+/// Used to represent that a ClientError will never occur.
+internal enum NoError {}
+
 /// Constructs an `InvalidArgument` error that indicates a missing value for
 /// the argument by the given name.
-internal func missingArgumentError(argumentName: String) -> CommandantError {
+internal func missingArgumentError<ClientError>(argumentName: String) -> CommandantError<ClientError> {
 	let description = "Missing argument for \(argumentName)"
-	return CommandantError.UsageError(description: description)
+	return .UsageError(description: description)
 }
 
 /// Constructs an error that describes how to use the option, with the given
 /// example of key (and value, if applicable) usage.
-internal func informativeUsageError<T>(keyValueExample: String, option: Option<T>) -> CommandantError {
+internal func informativeUsageError<T, ClientError>(keyValueExample: String, option: Option<T>) -> CommandantError<ClientError> {
 	var description = ""
 
 	if option.defaultValue != nil {
@@ -60,11 +63,11 @@ internal func informativeUsageError<T>(keyValueExample: String, option: Option<T
 			return previous + "\n\t" + value
 		}
 	
-	return CommandantError.UsageError(description: description)
+	return .UsageError(description: description)
 }
 
 /// Constructs an error that describes how to use the option.
-internal func informativeUsageError<T: ArgumentType>(option: Option<T>) -> CommandantError {
+internal func informativeUsageError<T: ArgumentType, ClientError>(option: Option<T>) -> CommandantError<ClientError> {
 	var example = ""
 
 	if let key = option.key {
@@ -86,7 +89,7 @@ internal func informativeUsageError<T: ArgumentType>(option: Option<T>) -> Comma
 }
 
 /// Constructs an error that describes how to use the given boolean option.
-internal func informativeUsageError(option: Option<Bool>) -> CommandantError {
+internal func informativeUsageError<ClientError>(option: Option<Bool>) -> CommandantError<ClientError> {
 	precondition(option.key != nil)
 
 	let key = option.key!
@@ -100,11 +103,11 @@ internal func informativeUsageError(option: Option<Bool>) -> CommandantError {
 
 /// Combines the text of the two errors, if they're both `UsageError`s.
 /// Otherwise, uses whichever one is not (biased toward the left).
-internal func combineUsageErrors(lhs: CommandantError, rhs: CommandantError) -> CommandantError {
+internal func combineUsageErrors<ClientError>(lhs: CommandantError<ClientError>, rhs: CommandantError<ClientError>) -> CommandantError<ClientError> {
 	switch (lhs, rhs) {
 	case let (.UsageError(left), .UsageError(right)):
 		let combinedDescription = "\(left)\n\n\(right)"
-		return CommandantError.UsageError(description: combinedDescription)
+		return .UsageError(description: combinedDescription)
 
 	case (.UsageError, _):
 		return rhs

--- a/Commandant/HelpCommand.swift
+++ b/Commandant/HelpCommand.swift
@@ -15,23 +15,23 @@ import LlamaKit
 /// If you want to use this command, initialize it with the registry, then add
 /// it to that same registry:
 ///
-/// 	let commands: CommandRegistry = …
+/// 	let commands: CommandRegistry<MyErrorType> = …
 /// 	let helpCommand = HelpCommand(registry: commands)
 /// 	commands.register(helpCommand)
-public struct HelpCommand: CommandType {
+public struct HelpCommand<ClientError>: CommandType {
 	public let verb = "help"
 	public let function = "Display general or command-specific help"
 
-	private let registry: CommandRegistry
+	private let registry: CommandRegistry<ClientError>
 
 	/// Initializes the command to provide help from the given registry of
 	/// commands.
-	public init(registry: CommandRegistry) {
+	public init(registry: CommandRegistry<ClientError>) {
 		self.registry = registry
 	}
 
-	public func run(mode: CommandMode) -> Result<(), CommandantError> {
-		return HelpOptions.evaluate(mode)
+	public func run(mode: CommandMode) -> Result<(), CommandantError<ClientError>> {
+		return HelpOptions<ClientError>.evaluate(mode)
 			.flatMap { options in
 				if let verb = options.verb {
 					if let command = self.registry[verb] {
@@ -61,7 +61,7 @@ public struct HelpCommand: CommandType {
 	}
 }
 
-private struct HelpOptions: OptionsType {
+private struct HelpOptions<ClientError>: OptionsType {
 	let verb: String?
 	
 	init(verb: String?) {
@@ -72,7 +72,7 @@ private struct HelpOptions: OptionsType {
 		return self(verb: (verb == "" ? nil : verb))
 	}
 
-	static func evaluate(m: CommandMode) -> Result<HelpOptions, CommandantError> {
+	static func evaluate(m: CommandMode) -> Result<HelpOptions, CommandantError<ClientError>> {
 		return create
 			<*> m <| Option(defaultValue: "", usage: "the command to display help for")
 	}

--- a/Commandant/Option.swift
+++ b/Commandant/Option.swift
@@ -34,11 +34,12 @@ import LlamaKit
 ///			}
 ///		}
 public protocol OptionsType {
+	typealias ClientError
+
 	/// Evaluates this set of options in the given mode.
 	///
-	/// Returns the parsed options, or an `InvalidArgument` error containing
-	/// usage information.
-	static func evaluate(m: CommandMode) -> Result<Self, CommandantError>
+	/// Returns the parsed options or a `UsageError`.
+	static func evaluate(m: CommandMode) -> Result<Self, CommandantError<ClientError>>
 }
 
 /// Describes an option that can be provided on the command line.
@@ -74,9 +75,9 @@ public struct Option<T> {
 
 	/// Constructs an `InvalidArgument` error that describes how the option was
 	/// used incorrectly. `value` should be the invalid value given by the user.
-	private func invalidUsageError(value: String) -> CommandantError {
+	private func invalidUsageError<ClientError>(value: String) -> CommandantError<ClientError> {
 		let description = "Invalid value for '\(self)': \(value)"
-		return CommandantError.UsageError(description: description)
+		return .UsageError(description: description)
 	}
 }
 
@@ -154,7 +155,7 @@ infix operator <| {
 ///
 /// In the context of command-line option parsing, this is used to chain
 /// together the parsing of multiple arguments. See OptionsType for an example.
-public func <*><T, U>(f: T -> U, value: Result<T, CommandantError>) -> Result<U, CommandantError> {
+public func <*> <T, U, ClientError>(f: T -> U, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>> {
 	return value.map(f)
 }
 
@@ -162,7 +163,7 @@ public func <*><T, U>(f: T -> U, value: Result<T, CommandantError>) -> Result<U,
 ///
 /// In the context of command-line option parsing, this is used to chain
 /// together the parsing of multiple arguments. See OptionsType for an example.
-public func <*><T, U>(f: Result<(T -> U), CommandantError>, value: Result<T, CommandantError>) -> Result<U, CommandantError> {
+public func <*> <T, U, ClientError>(f: Result<(T -> U), CommandantError<ClientError>>, value: Result<T, CommandantError<ClientError>>) -> Result<U, CommandantError<ClientError>> {
 	switch (f, value) {
 	case let (.Failure(left), .Failure(right)):
 		return failure(combineUsageErrors(left.unbox, right.unbox))
@@ -183,7 +184,7 @@ public func <*><T, U>(f: Result<(T -> U), CommandantError>, value: Result<T, Com
 ///
 /// If parsing command line arguments, and no value was specified on the command
 /// line, the option's `defaultValue` is used.
-public func <|<T: ArgumentType>(mode: CommandMode, option: Option<T>) -> Result<T, CommandantError> {
+public func <| <T: ArgumentType, ClientError>(mode: CommandMode, option: Option<T>) -> Result<T, CommandantError<ClientError>> {
 	switch mode {
 	case let .Arguments(arguments):
 		var stringValue: String?
@@ -193,7 +194,13 @@ public func <|<T: ArgumentType>(mode: CommandMode, option: Option<T>) -> Result<
 				stringValue = value.unbox
 
 			case let .Failure(error):
-				return failure(error.unbox)
+				switch error.unbox {
+				case let .UsageError(description):
+					return failure(.UsageError(description: description))
+
+				case .CommandError:
+					fatalError("CommandError should be impossible when parameterized over NoError")
+				}
 			}
 		} else {
 			stringValue = arguments.consumePositionalArgument()
@@ -220,7 +227,7 @@ public func <|<T: ArgumentType>(mode: CommandMode, option: Option<T>) -> Result<
 ///
 /// If parsing command line arguments, and no value was specified on the command
 /// line, the option's `defaultValue` is used.
-public func <|(mode: CommandMode, option: Option<Bool>) -> Result<Bool, CommandantError> {
+public func <| <ClientError>(mode: CommandMode, option: Option<Bool>) -> Result<Bool, CommandantError<ClientError>> {
 	precondition(option.key != nil)
 
 	switch mode {

--- a/CommandantTests/OptionSpec.swift
+++ b/CommandantTests/OptionSpec.swift
@@ -12,10 +12,12 @@ import LlamaKit
 import Nimble
 import Quick
 
+enum NoError {}
+
 class OptionsTypeSpec: QuickSpec {
 	override func spec() {
 		describe("CommandMode.Arguments") {
-			func tryArguments(arguments: String...) -> Result<TestOptions, CommandantError> {
+			func tryArguments(arguments: String...) -> Result<TestOptions, CommandantError<NoError>> {
 				return TestOptions.evaluate(.Arguments(ArgumentParser(arguments)))
 			}
 
@@ -87,7 +89,7 @@ struct TestOptions: OptionsType, Equatable {
 		return self(intValue: a, stringValue: b, optionalFilename: d, requiredName: c, enabled: e)
 	}
 
-	static func evaluate(m: CommandMode) -> Result<TestOptions, CommandantError> {
+	static func evaluate(m: CommandMode) -> Result<TestOptions, CommandantError<NoError>> {
 		return create
 			<*> m <| Option(key: "intValue", defaultValue: 42, usage: "Some integer value")
 			<*> m <| Option(key: "stringValue", defaultValue: "foobar", usage: "Some string value")


### PR DESCRIPTION
This allows clients to pass through errors that occur when running their commands.

/cc @jpsim who asked about this in chat a while ago, I think