### PR TITLE
Generate error on unrecognized arguments

### DIFF
--- a/Commandant/ArgumentParser.swift
+++ b/Commandant/ArgumentParser.swift
@@ -85,7 +85,7 @@ public final class ArgumentParser {
 			rawArguments.appendContentsOf(positional.map { .Value($0) })
 		}
 	}
-	
+
 	/// Returns whether the given key was enabled or disabled, or nil if it
 	/// was not given at all.
 	///

--- a/Commandant/ArgumentParser.swift
+++ b/Commandant/ArgumentParser.swift
@@ -85,6 +85,10 @@ public final class ArgumentParser {
 			rawArguments.appendContentsOf(positional.map { .Value($0) })
 		}
 	}
+	
+	deinit {
+		print("\nUnknown arguments are ignored:", rawArguments.map { $0.description }.joinWithSeparator(","))
+	}
 
 	/// Returns whether the given key was enabled or disabled, or nil if it
 	/// was not given at all.

--- a/Commandant/ArgumentParser.swift
+++ b/Commandant/ArgumentParser.swift
@@ -86,10 +86,6 @@ public final class ArgumentParser {
 		}
 	}
 	
-	deinit {
-		print("\nUnknown arguments are ignored:", rawArguments.map { $0.description }.joinWithSeparator(","))
-	}
-
 	/// Returns whether the given key was enabled or disabled, or nil if it
 	/// was not given at all.
 	///
@@ -194,5 +190,10 @@ public final class ArgumentParser {
 		}
 
 		return false
+	}
+	
+	/// Returns remaining arguments
+	internal var remainingArguments: [String]? {
+		return rawArguments.isEmpty ? nil : rawArguments.map { $0.description }
 	}
 }

--- a/Commandant/Command.swift
+++ b/Commandant/Command.swift
@@ -77,7 +77,12 @@ public final class CommandRegistry<ClientError> {
 	///
 	/// Returns the results of the execution, or nil if no such command exists.
 	public func runCommand(verb: String, arguments: [String]) -> Result<(), CommandantError<ClientError>>? {
-		return self[verb]?.run(.Arguments(ArgumentParser(arguments)))
+		let argumentsParser = ArgumentParser(arguments)
+		let result = self[verb]?.run(.Arguments(argumentsParser))
+		if let remainingArguments = argumentsParser.remainingArguments {
+			print("\nUnknown arguments are ignored:", remainingArguments.joinWithSeparator(","))
+		}
+		return result
 	}
 
 	/// Returns the command matching the given verb, or nil if no such command

--- a/Commandant/Command.swift
+++ b/Commandant/Command.swift
@@ -77,12 +77,7 @@ public final class CommandRegistry<ClientError> {
 	///
 	/// Returns the results of the execution, or nil if no such command exists.
 	public func runCommand(verb: String, arguments: [String]) -> Result<(), CommandantError<ClientError>>? {
-		let argumentsParser = ArgumentParser(arguments)
-		let result = self[verb]?.run(.Arguments(argumentsParser))
-		if let remainingArguments = argumentsParser.remainingArguments {
-			print("\nUnknown arguments are ignored:", remainingArguments.joinWithSeparator(","))
-		}
-		return result
+		return self[verb]?.run(.Arguments(ArgumentParser(arguments)))
 	}
 
 	/// Returns the command matching the given verb, or nil if no such command

--- a/Commandant/Errors.swift
+++ b/Commandant/Errors.swift
@@ -113,3 +113,8 @@ internal func combineUsageErrors<ClientError>(lhs: CommandantError<ClientError>,
 		return lhs
 	}
 }
+
+/// Constructs an error that unknown options are specified.
+internal func unknownOptionsError<ClientError>(options: [String]) -> CommandantError<ClientError> {
+	return .UsageError(description: "Unknown options: " + options.joinWithSeparator(","))
+}

--- a/Commandant/Errors.swift
+++ b/Commandant/Errors.swift
@@ -114,7 +114,7 @@ internal func combineUsageErrors<ClientError>(lhs: CommandantError<ClientError>,
 	}
 }
 
-/// Constructs an error that unknown options are specified.
-internal func unknownOptionsError<ClientError>(options: [String]) -> CommandantError<ClientError> {
-	return .UsageError(description: "Unknown options: " + options.joinWithSeparator(","))
+/// Constructs an error that indicates unrecognized arguments remains.
+internal func unrecognizedArgumentsError<ClientError>(options: [String]) -> CommandantError<ClientError> {
+	return .UsageError(description: "Unrecognized arguments: " + options.joinWithSeparator(","))
 }

--- a/Commandant/HelpCommand.swift
+++ b/Commandant/HelpCommand.swift
@@ -31,7 +31,7 @@ public struct HelpCommand<ClientError>: CommandType {
 	}
 
 	public func run(mode: CommandMode) -> Result<(), CommandantError<ClientError>> {
-		return HelpOptions<ClientError>.evaluateAndCheckUnknownArguments(mode)
+		return HelpOptions<ClientError>.evaluateAndCheckUnrecognizedArguments(mode)
 			.flatMap { options in
 				if let verb = options.verb {
 					if let command = self.registry[verb] {

--- a/Commandant/HelpCommand.swift
+++ b/Commandant/HelpCommand.swift
@@ -31,7 +31,7 @@ public struct HelpCommand<ClientError>: CommandType {
 	}
 
 	public func run(mode: CommandMode) -> Result<(), CommandantError<ClientError>> {
-		return HelpOptions<ClientError>.evaluate(mode)
+		return HelpOptions<ClientError>.evaluateAndCheckUnknownArguments(mode)
 			.flatMap { options in
 				if let verb = options.verb {
 					if let command = self.registry[verb] {

--- a/Commandant/Option.swift
+++ b/Commandant/Option.swift
@@ -43,6 +43,21 @@ public protocol OptionsType {
 	static func evaluate(m: CommandMode) -> Result<Self, CommandantError<ClientError>>
 }
 
+/// Evaluates and checks unknown arguments.
+/// If unknown arguments are detected, it returns a `UsageError` describing "unknown options".
+///
+/// Returns the parsed options or a `UsageError`
+extension OptionsType {
+	public static func evaluateAndCheckUnknownArguments(m: CommandMode) -> Result<Self, CommandantError<ClientError>> {
+		let result = evaluate(m)
+		if case let .Arguments(argumentsParser) = m,
+			let remainingArguments = argumentsParser.remainingArguments {
+			return .Failure(unknownOptionsError(remainingArguments))
+		}
+		return result
+	}
+}
+
 /// Describes an option that can be provided on the command line.
 public struct Option<T> {
 	/// The key that controls this option. For example, a key of `verbose` would

--- a/Commandant/Option.swift
+++ b/Commandant/Option.swift
@@ -43,16 +43,16 @@ public protocol OptionsType {
 	static func evaluate(m: CommandMode) -> Result<Self, CommandantError<ClientError>>
 }
 
-/// Evaluates and checks unknown arguments.
-/// If unknown arguments are detected, it returns a `UsageError` describing "unknown options".
+/// Evaluates and checks unrecognized arguments remains.
+/// If unrecognized arguments are detected, it returns a `UsageError` indicates "unrecognized arguments".
 ///
 /// Returns the parsed options or a `UsageError`
 extension OptionsType {
-	public static func evaluateAndCheckUnknownArguments(m: CommandMode) -> Result<Self, CommandantError<ClientError>> {
+	public static func evaluateAndCheckUnrecognizedArguments(m: CommandMode) -> Result<Self, CommandantError<ClientError>> {
 		let result = evaluate(m)
 		if case let .Arguments(argumentsParser) = m,
 			let remainingArguments = argumentsParser.remainingArguments {
-			return .Failure(unknownOptionsError(remainingArguments))
+			return .Failure(unrecognizedArgumentsError(remainingArguments))
 		}
 		return result
 	}

--- a/CommandantTests/OptionSpec.swift
+++ b/CommandantTests/OptionSpec.swift
@@ -18,7 +18,7 @@ class OptionsTypeSpec: QuickSpec {
 	override func spec() {
 		describe("CommandMode.Arguments") {
 			func tryArguments(arguments: String...) -> Result<TestOptions, CommandantError<NoError>> {
-				return TestOptions.evaluate(.Arguments(ArgumentParser(arguments)))
+				return TestOptions.evaluateAndCheckUnknownArguments(.Arguments(ArgumentParser(arguments)))
 			}
 
 			it("should fail if a required argument is missing") {
@@ -69,6 +69,12 @@ class OptionsTypeSpec: QuickSpec {
 				let value = tryArguments("--", "--intValue").value
 				let expected = TestOptions(intValue: 42, stringValue: "foobar", optionalFilename: "filename", requiredName: "--intValue", enabled: false, force: false, glob: false)
 				expect(value).to(equal(expected))
+			}
+			
+			it("should error with unknown arguments") {
+				let error = tryArguments("--enabled", "--unknown").error
+				expect(error?.description).toNot(contain("--enabled"))
+				expect(error?.description).to(contain("--unknown"))
 			}
 		}
 

--- a/CommandantTests/OptionSpec.swift
+++ b/CommandantTests/OptionSpec.swift
@@ -18,7 +18,7 @@ class OptionsTypeSpec: QuickSpec {
 	override func spec() {
 		describe("CommandMode.Arguments") {
 			func tryArguments(arguments: String...) -> Result<TestOptions, CommandantError<NoError>> {
-				return TestOptions.evaluateAndCheckUnknownArguments(.Arguments(ArgumentParser(arguments)))
+				return TestOptions.evaluateAndCheckUnrecognizedArguments(.Arguments(ArgumentParser(arguments)))
 			}
 
 			it("should fail if a required argument is missing") {
@@ -71,10 +71,10 @@ class OptionsTypeSpec: QuickSpec {
 				expect(value).to(equal(expected))
 			}
 			
-			it("should error with unknown arguments") {
-				let error = tryArguments("--enabled", "--unknown").error
+			it("should generate error when unrecognized arguments remains") {
+				let error = tryArguments("--enabled", "--unrecognized").error
 				expect(error?.description).toNot(contain("--enabled"))
-				expect(error?.description).to(contain("--unknown"))
+				expect(error?.description).to(contain("--unrecognized"))
 			}
 		}
 


### PR DESCRIPTION
It will alert users to the typo of arguments.

e.g.
```sh
% carthage checkout --use-submodule
*** Checking out xcconfigs at "ec5753493605deed7358dec5f9260f503d3ed650"

Unknown arguments are ignored: --use-submodule
%
```