### PR TITLE
Generate an error against unrecognized arguments

### DIFF
--- a/Commandant/ArgumentParser.swift
+++ b/Commandant/ArgumentParser.swift
@@ -86,6 +86,11 @@ public final class ArgumentParser {
 		}
 	}
 
+	/// Returns the remaining arguments.
+	internal var remainingArguments: [String]? {
+		return rawArguments.isEmpty ? nil : rawArguments.map { $0.description }
+	}
+
 	/// Returns whether the given key was enabled or disabled, or nil if it
 	/// was not given at all.
 	///

--- a/Commandant/Command.swift
+++ b/Commandant/Command.swift
@@ -44,6 +44,11 @@ public struct CommandWrapper<ClientError: ErrorType> {
 		function = command.function
 		run = { (arguments: ArgumentParser) -> Result<(), CommandantError<ClientError>> in
 			let options = C.Options.evaluate(.Arguments(arguments))
+
+			if let remainingArguments = arguments.remainingArguments {
+				return .Failure(unrecognizedArgumentsError(remainingArguments))
+			}
+
 			if let options = options.value {
 				command.run(options)
 				return .Success()

--- a/Commandant/Errors.swift
+++ b/Commandant/Errors.swift
@@ -113,3 +113,8 @@ internal func combineUsageErrors<ClientError>(lhs: CommandantError<ClientError>,
 		return lhs
 	}
 }
+
+/// Constructs an error that indicates unrecognized arguments remains.
+internal func unrecognizedArgumentsError<ClientError>(options: [String]) -> CommandantError<ClientError> {
+	return .UsageError(description: "Unrecognized arguments: " + options.joinWithSeparator(", "))
+}


### PR DESCRIPTION
This is based on the implementations of #34 and #41. Resolves #2.

~~If a command specifies its associated options type in its `public typealias Options = ...` when that is `OptionsType`, the options will be evaluated and validated before the actual command runs.~~

/cc @norio-nomura, @mdiep 