### PR TITLE
Give Commands Options

### DIFF
--- a/Commandant/Command.swift
+++ b/Commandant/Command.swift
@@ -12,6 +12,9 @@ import Result
 /// Represents a subcommand that can be executed with its own set of arguments.
 public protocol CommandType {
 	typealias ClientError
+	
+	/// The command's options type.
+	typealias Options: OptionsType
 
 	/// The action that users should specify to use this subcommand (e.g.,
 	/// `help`).

--- a/Commandant/Command.swift
+++ b/Commandant/Command.swift
@@ -39,7 +39,7 @@ public struct CommandWrapper<ClientError: ErrorType> {
 	public let usage: () -> CommandantError<ClientError>
 
 	/// Creates a command that wraps another.
-	init<C: CommandType where C.Options.ClientError == ClientError>(_ command: C) {
+	private init<C: CommandType where C.Options.ClientError == ClientError>(_ command: C) {
 		verb = command.verb
 		function = command.function
 		run = { (arguments: ArgumentParser) -> Result<(), CommandantError<ClientError>> in

--- a/Commandant/Command.swift
+++ b/Commandant/Command.swift
@@ -30,7 +30,7 @@ public protocol CommandType {
 }
 
 /// A type-erased command.
-public struct AnyCommand<ClientError: ErrorType> {
+public struct CommandWrapper<ClientError: ErrorType> {
 	public let verb: String
 	public let function: String
 	
@@ -69,10 +69,10 @@ public enum CommandMode {
 
 /// Maintains the list of commands available to run.
 public final class CommandRegistry<ClientError: ErrorType> {
-	private var commandsByVerb: [String: AnyCommand<ClientError>] = [:]
+	private var commandsByVerb: [String: CommandWrapper<ClientError>] = [:]
 
 	/// All available commands.
-	public var commands: [AnyCommand<ClientError>] {
+	public var commands: [CommandWrapper<ClientError>] {
 		return commandsByVerb.values.sort { return $0.verb < $1.verb }
 	}
 
@@ -83,7 +83,7 @@ public final class CommandRegistry<ClientError: ErrorType> {
 	/// If another command was already registered with the same `verb`, it will
 	/// be overwritten.
 	public func register<C: CommandType where C.Options.ClientError == ClientError>(command: C) {
-		commandsByVerb[command.verb] = AnyCommand(command)
+		commandsByVerb[command.verb] = CommandWrapper(command)
 	}
 
 	/// Runs the command corresponding to the given verb, passing it the given
@@ -96,7 +96,7 @@ public final class CommandRegistry<ClientError: ErrorType> {
 
 	/// Returns the command matching the given verb, or nil if no such command
 	/// is registered.
-	public subscript(verb: String) -> AnyCommand<ClientError>? {
+	public subscript(verb: String) -> CommandWrapper<ClientError>? {
 		return commandsByVerb[verb]
 	}
 }

--- a/Commandant/Command.swift
+++ b/Commandant/Command.swift
@@ -25,8 +25,8 @@ public protocol CommandType {
 	func run(mode: CommandMode) -> Result<(), CommandantError<ClientError>>
 }
 
-/// A type-erased CommandType.
-public struct AnyCommand<ClientError>: CommandType {
+/// A type-erased command.
+public struct AnyCommand<ClientError> {
 	public let verb: String
 	public let function: String
 	private let runClosure: CommandMode -> Result<(), CommandantError<ClientError>>

--- a/Commandant/Command.swift
+++ b/Commandant/Command.swift
@@ -11,11 +11,12 @@ import Result
 
 /// Represents a subcommand that can be executed with its own set of arguments.
 public protocol CommandType {
-	typealias ClientError
 	
 	/// The command's options type.
 	typealias Options: OptionsType
 
+	typealias ClientError: ErrorType = Options.ClientError
+	
 	/// The action that users should specify to use this subcommand (e.g.,
 	/// `help`).
 	var verb: String { get }
@@ -24,25 +25,35 @@ public protocol CommandType {
 	/// for.
 	var function: String { get }
 
-	/// Runs this subcommand in the given mode.
-	func run(mode: CommandMode) -> Result<(), CommandantError<ClientError>>
+	/// Runs this subcommand with the given options.
+	func run(options: Options) -> Result<(), ClientError>
 }
 
 /// A type-erased command.
-public struct AnyCommand<ClientError> {
+public struct AnyCommand<ClientError: ErrorType> {
 	public let verb: String
 	public let function: String
-	private let runClosure: CommandMode -> Result<(), CommandantError<ClientError>>
+	
+	public let run: ArgumentParser -> Result<(), CommandantError<ClientError>>
+	
+	public let usage: () -> CommandantError<ClientError>
 
 	/// Creates a command that wraps another.
-	public init<C: CommandType where C.ClientError == ClientError>(_ command: C) {
+	init<C: CommandType where C.Options.ClientError == ClientError>(_ command: C) {
 		verb = command.verb
 		function = command.function
-		runClosure = { mode in command.run(mode) }
-	}
-
-	public func run(mode: CommandMode) -> Result<(), CommandantError<ClientError>> {
-		return runClosure(mode)
+		run = { (arguments: ArgumentParser)-> Result<(), CommandantError<ClientError>>  in
+			let options = C.Options.evaluate(.Arguments(arguments))
+			if let options = options.value {
+				command.run(options)
+				return .Success()
+			} else {
+				return .Failure(options.error!)
+			}
+		}
+		usage = { () -> CommandantError<ClientError> in
+			return C.Options.evaluate(.Usage).error!
+		}
 	}
 }
 
@@ -57,7 +68,7 @@ public enum CommandMode {
 }
 
 /// Maintains the list of commands available to run.
-public final class CommandRegistry<ClientError> {
+public final class CommandRegistry<ClientError: ErrorType> {
 	private var commandsByVerb: [String: AnyCommand<ClientError>] = [:]
 
 	/// All available commands.
@@ -71,7 +82,7 @@ public final class CommandRegistry<ClientError> {
 	///
 	/// If another command was already registered with the same `verb`, it will
 	/// be overwritten.
-	public func register<C: CommandType where C.ClientError == ClientError>(command: C) {
+	public func register<C: CommandType where C.Options.ClientError == ClientError>(command: C) {
 		commandsByVerb[command.verb] = AnyCommand(command)
 	}
 
@@ -80,7 +91,7 @@ public final class CommandRegistry<ClientError> {
 	///
 	/// Returns the results of the execution, or nil if no such command exists.
 	public func runCommand(verb: String, arguments: [String]) -> Result<(), CommandantError<ClientError>>? {
-		return self[verb]?.run(.Arguments(ArgumentParser(arguments)))
+		return self[verb]?.run(ArgumentParser(arguments))
 	}
 
 	/// Returns the command matching the given verb, or nil if no such command

--- a/Commandant/Command.swift
+++ b/Commandant/Command.swift
@@ -42,7 +42,7 @@ public struct CommandWrapper<ClientError: ErrorType> {
 	init<C: CommandType where C.Options.ClientError == ClientError>(_ command: C) {
 		verb = command.verb
 		function = command.function
-		run = { (arguments: ArgumentParser)-> Result<(), CommandantError<ClientError>>  in
+		run = { (arguments: ArgumentParser) -> Result<(), CommandantError<ClientError>> in
 			let options = C.Options.evaluate(.Arguments(arguments))
 			if let options = options.value {
 				command.run(options)

--- a/Commandant/Errors.swift
+++ b/Commandant/Errors.swift
@@ -34,7 +34,7 @@ extension CommandantError: CustomStringConvertible {
 }
 
 /// Used to represent that a ClientError will never occur.
-internal enum NoError {}
+internal enum NoError: ErrorType {}
 
 /// Constructs an `InvalidArgument` error that indicates a missing value for
 /// the argument by the given name.

--- a/Commandant/HelpCommand.swift
+++ b/Commandant/HelpCommand.swift
@@ -18,7 +18,7 @@ import Result
 /// 	let commands: CommandRegistry<MyErrorType> = …
 /// 	let helpCommand = HelpCommand(registry: commands)
 /// 	commands.register(helpCommand)
-public struct HelpCommand<ClientError>: CommandType {
+public struct HelpCommand<ClientError: ErrorType>: CommandType {
 	public typealias Options = HelpOptions<ClientError>
 	public let verb = "help"
 	public let function = "Display general or command-specific help"
@@ -31,33 +31,31 @@ public struct HelpCommand<ClientError>: CommandType {
 		self.registry = registry
 	}
 
-	public func run(mode: CommandMode) -> Result<(), CommandantError<ClientError>> {
-		return HelpOptions<ClientError>.evaluate(mode)
-			.flatMap { options in
-				if let verb = options.verb {
-					if let command = self.registry[verb] {
-						print(command.function, terminator: "\n\n")
-						return command.run(.Usage)
-					} else {
-						fputs("Unrecognized command: '\(verb)'\n", stderr)
-					}
-				}
-
-				print("Available commands:\n")
-
-				let maxVerbLength = self.registry.commands.map { $0.verb.characters.count }.maxElement() ?? 0
-
-				for command in self.registry.commands {
-					let padding = Repeat<Character>(count: maxVerbLength - command.verb.characters.count, repeatedValue: " ")
-					print("   \(command.verb)\(String(padding))   \(command.function)")
-				}
-
+	public func run(options: Options) -> Result<(), ClientError> {
+		if let verb = options.verb {
+			if let command = self.registry[verb] {
+				print(command.function, terminator: "\n\n")
+				print(command.usage())
 				return .Success(())
+			} else {
+				fputs("Unrecognized command: '\(verb)'\n", stderr)
 			}
+		}
+
+		print("Available commands:\n")
+
+		let maxVerbLength = self.registry.commands.map { $0.verb.characters.count }.maxElement() ?? 0
+
+		for command in self.registry.commands {
+			let padding = Repeat<Character>(count: maxVerbLength - command.verb.characters.count, repeatedValue: " ")
+			print("   \(command.verb)\(String(padding))   \(command.function)")
+		}
+
+		return .Success(())
 	}
 }
 
-public struct HelpOptions<ClientError>: OptionsType {
+public struct HelpOptions<ClientError: ErrorType>: OptionsType {
 	let verb: String?
 	
 	init(verb: String?) {

--- a/Commandant/HelpCommand.swift
+++ b/Commandant/HelpCommand.swift
@@ -19,6 +19,7 @@ import Result
 /// 	let helpCommand = HelpCommand(registry: commands)
 /// 	commands.register(helpCommand)
 public struct HelpCommand<ClientError>: CommandType {
+	public typealias Options = HelpOptions<ClientError>
 	public let verb = "help"
 	public let function = "Display general or command-specific help"
 
@@ -56,7 +57,7 @@ public struct HelpCommand<ClientError>: CommandType {
 	}
 }
 
-private struct HelpOptions<ClientError>: OptionsType {
+public struct HelpOptions<ClientError>: OptionsType {
 	let verb: String?
 	
 	init(verb: String?) {
@@ -67,7 +68,7 @@ private struct HelpOptions<ClientError>: OptionsType {
 		return self.init(verb: (verb == "" ? nil : verb))
 	}
 
-	static func evaluate(m: CommandMode) -> Result<HelpOptions, CommandantError<ClientError>> {
+	public static func evaluate(m: CommandMode) -> Result<HelpOptions, CommandantError<ClientError>> {
 		return create
 			<*> m <| Option(defaultValue: "", usage: "the command to display help for")
 	}

--- a/Commandant/HelpCommand.swift
+++ b/Commandant/HelpCommand.swift
@@ -57,13 +57,13 @@ public struct HelpCommand<ClientError: ErrorType>: CommandType {
 }
 
 public struct HelpOptions<ClientError: ErrorType>: OptionsType {
-	let verb: String?
+	private let verb: String?
 	
-	init(verb: String?) {
+	private init(verb: String?) {
 		self.verb = verb
 	}
 
-	static func create(verb: String) -> HelpOptions {
+	private static func create(verb: String) -> HelpOptions {
 		return self.init(verb: (verb == "" ? nil : verb))
 	}
 

--- a/Commandant/HelpCommand.swift
+++ b/Commandant/HelpCommand.swift
@@ -20,6 +20,7 @@ import Result
 /// 	commands.register(helpCommand)
 public struct HelpCommand<ClientError: ErrorType>: CommandType {
 	public typealias Options = HelpOptions<ClientError>
+
 	public let verb = "help"
 	public let function = "Display general or command-specific help"
 

--- a/Commandant/Option.swift
+++ b/Commandant/Option.swift
@@ -43,6 +43,15 @@ public protocol OptionsType {
 	static func evaluate(m: CommandMode) -> Result<Self, CommandantError<ClientError>>
 }
 
+/// An `OptionsType` that has no options.
+public struct NoOptions<ClientError: ErrorType>: OptionsType {
+	private init() {}
+	
+	public static func evaluate(m: CommandMode) -> Result<NoOptions, CommandantError<ClientError>> {
+		return .Success(NoOptions())
+	}
+}
+
 /// Describes an option that can be provided on the command line.
 public struct Option<T> {
 	/// The key that controls this option. For example, a key of `verbose` would

--- a/Commandant/Option.swift
+++ b/Commandant/Option.swift
@@ -35,7 +35,7 @@ import Result
 ///			}
 ///		}
 public protocol OptionsType {
-	typealias ClientError
+	typealias ClientError: ErrorType
 
 	/// Evaluates this set of options in the given mode.
 	///

--- a/CommandantTests/OptionSpec.swift
+++ b/CommandantTests/OptionSpec.swift
@@ -6,13 +6,11 @@
 //  Copyright (c) 2014 Carthage. All rights reserved.
 //
 
-import Commandant
+@testable import Commandant
 import Foundation
 import Nimble
 import Quick
 import Result
-
-enum NoError: ErrorType {}
 
 class OptionsTypeSpec: QuickSpec {
 	override func spec() {

--- a/CommandantTests/OptionSpec.swift
+++ b/CommandantTests/OptionSpec.swift
@@ -12,7 +12,7 @@ import Nimble
 import Quick
 import Result
 
-enum NoError {}
+enum NoError: ErrorType {}
 
 class OptionsTypeSpec: QuickSpec {
 	override func spec() {
@@ -92,6 +92,8 @@ struct TestOptions: OptionsType, Equatable {
 	let enabled: Bool
 	let force: Bool
 	let glob: Bool
+	
+	typealias ClientError = NoError
 
 	static func create(a: Int)(b: String)(c: String)(d: String)(e: Bool)(f: Bool)(g: Bool) -> TestOptions {
 		return self.init(intValue: a, stringValue: b, optionalFilename: d, requiredName: c, enabled: e, force: f, glob: g)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ struct LogCommand: CommandType {
 	let verb = "log"
 	let function = "Reads the log"
 
-	func run(options: Options) -> Result<(), YourErrorType
+	func run(options: Options) -> Result<(), YourErrorType> {
 		// Use the parsed options to do something interesting here.
 		return ()
 	}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ With Commandant, a command and its associated options could be defined as follow
 ```swift
 struct LogCommand: CommandType {
 	typealias Options = LogOptions
+
 	let verb = "log"
 	let function = "Reads the log"
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@ With Commandant, a command and its associated options could be defined as follow
 
 ```swift
 struct LogCommand: CommandType {
+	typealias Options = LogOptions
 	let verb = "log"
 	let function = "Reads the log"
 
-	func run(mode: CommandMode) -> Result<(), CommandantError<YourErrorType>> {
-		return LogOptions.evaluate(mode).map { options in
-			// Use the parsed options to do something interesting here.
-			return ()
-		}
+	func run(options: Options) -> Result<(), YourErrorType
+		// Use the parsed options to do something interesting here.
+		return ()
 	}
 }
 


### PR DESCRIPTION
This introduces some breaking changes to try to simplify the interaction of `CommandType` and `OptionsType`:

- Add a `typealias Options: OptionsType` to `CommandType`
- Make `ClientError`s conform to `ErrorType`
- Parse options from `OptionsType`s automatically
- Change `CommandType.run()` to take `Options` instead of `CommandMode`
- Don't make `AnyCommand` conform to `CommandType`
- Add `AnyCommand.usage()`

This would greatly simplify something like #40 because options are no longer parsed by commands. It also removes a decent amount of boilerplate from commands.