### PR TITLE
Introduce `Argument` type which can handle an argument list

### DIFF
--- a/Commandant.xcodeproj/project.pbxproj
+++ b/Commandant.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CD2ED3431C1E6D540076092B /* ArgumentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2ED3421C1E6D540076092B /* ArgumentType.swift */; };
 		D00CCDDF1A20717400109F8C /* Commandant.h in Headers */ = {isa = PBXBuildFile; fileRef = D00CCDDE1A20717400109F8C /* Commandant.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D00CCDE51A20717400109F8C /* Commandant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D00CCDD91A20717400109F8C /* Commandant.framework */; };
 		D00CCE241A2073DA00109F8C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D00CCE221A2073DA00109F8C /* Nimble.framework */; };
@@ -32,6 +33,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		CD2ED3421C1E6D540076092B /* ArgumentType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArgumentType.swift; sourceTree = "<group>"; };
 		D00CCDD91A20717400109F8C /* Commandant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Commandant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D00CCDDD1A20717400109F8C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D00CCDDE1A20717400109F8C /* Commandant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Commandant.h; sourceTree = "<group>"; };
@@ -218,6 +220,7 @@
 			isa = PBXGroup;
 			children = (
 				D00CCE2C1A2075ED00109F8C /* ArgumentParser.swift */,
+				CD2ED3421C1E6D540076092B /* ArgumentType.swift */,
 				D00CCE261A20741300109F8C /* Command.swift */,
 				D00CCE2A1A20748500109F8C /* Errors.swift */,
 				D00CCE2E1A2075F700109F8C /* Option.swift */,
@@ -344,6 +347,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D0BF14FB1A4C8957003147BC /* HelpCommand.swift in Sources */,
+				CD2ED3431C1E6D540076092B /* ArgumentType.swift in Sources */,
 				D00CCE2F1A2075F700109F8C /* Option.swift in Sources */,
 				D00CCE2B1A20748500109F8C /* Errors.swift in Sources */,
 				D8169D871ACB942D00923FB0 /* Switch.swift in Sources */,

--- a/Commandant.xcodeproj/project.pbxproj
+++ b/Commandant.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CD2ED3411C1E6C5D0076092B /* Argument.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2ED3401C1E6C5D0076092B /* Argument.swift */; };
 		CD2ED3431C1E6D540076092B /* ArgumentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2ED3421C1E6D540076092B /* ArgumentType.swift */; };
 		D00CCDDF1A20717400109F8C /* Commandant.h in Headers */ = {isa = PBXBuildFile; fileRef = D00CCDDE1A20717400109F8C /* Commandant.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D00CCDE51A20717400109F8C /* Commandant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D00CCDD91A20717400109F8C /* Commandant.framework */; };
@@ -33,6 +34,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		CD2ED3401C1E6C5D0076092B /* Argument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Argument.swift; sourceTree = "<group>"; };
 		CD2ED3421C1E6D540076092B /* ArgumentType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArgumentType.swift; sourceTree = "<group>"; };
 		D00CCDD91A20717400109F8C /* Commandant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Commandant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D00CCDDD1A20717400109F8C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -219,6 +221,7 @@
 		D0BF14F81A4C892E003147BC /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				CD2ED3401C1E6C5D0076092B /* Argument.swift */,
 				D00CCE2C1A2075ED00109F8C /* ArgumentParser.swift */,
 				CD2ED3421C1E6D540076092B /* ArgumentType.swift */,
 				D00CCE261A20741300109F8C /* Command.swift */,
@@ -346,6 +349,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD2ED3411C1E6C5D0076092B /* Argument.swift in Sources */,
 				D0BF14FB1A4C8957003147BC /* HelpCommand.swift in Sources */,
 				CD2ED3431C1E6D540076092B /* ArgumentType.swift in Sources */,
 				D00CCE2F1A2075F700109F8C /* Option.swift in Sources */,

--- a/Commandant/Argument.swift
+++ b/Commandant/Argument.swift
@@ -1,0 +1,96 @@
+//
+//  Argument.swift
+//  Commandant
+//
+//  Created by Syo Ikeda on 12/14/15.
+//  Copyright (c) 2015 Carthage. All rights reserved.
+//
+
+import Result
+
+/// Describes an argument that can be provided on the command line.
+public struct Argument<T> {
+	/// The default value for this argument. This is the value that will be used
+	/// if the argument is never explicitly specified on the command line.
+	///
+	/// If this is nil, this argument is always required.
+	public let defaultValue: T?
+
+	/// A human-readable string describing the purpose of this argument. This will
+	/// be shown in help messages.
+	public let usage: String
+
+	public init(defaultValue: T? = nil, usage: String) {
+		self.defaultValue = defaultValue
+		self.usage = usage
+	}
+
+	private func invalidUsageError<ClientError>(value: String) -> CommandantError<ClientError> {
+		let description = "Invalid value for '\(self)': \(value)"
+		return .UsageError(description: description)
+	}
+}
+
+/// Evaluates the given argument in the given mode.
+///
+/// If parsing command line arguments, and no value was specified on the command
+/// line, the option's `defaultValue` is used.
+public func <| <T: ArgumentType, ClientError>(mode: CommandMode, argument: Argument<T>) -> Result<T, CommandantError<ClientError>> {
+	switch mode {
+	case let .Arguments(arguments):
+		guard let stringValue = arguments.consumePositionalArgument() else {
+			if let defaultValue = argument.defaultValue {
+				return .Success(defaultValue)
+			} else {
+				return .Failure(missingArgumentError(argument.usage))
+			}
+		}
+
+		if let value = T.fromString(stringValue) {
+			return .Success(value)
+		} else {
+			return .Failure(argument.invalidUsageError(stringValue))
+		}
+
+	case .Usage:
+		return .Failure(informativeUsageError(argument))
+	}
+}
+
+/// Evaluates the given argument list in the given mode.
+///
+/// If parsing command line arguments, and no value was specified on the command
+/// line, the option's `defaultValue` is used.
+public func <| <T: ArgumentType, ClientError>(mode: CommandMode, argument: Argument<[T]>) -> Result<[T], CommandantError<ClientError>> {
+	switch mode {
+	case let .Arguments(arguments):
+		guard let firstValue = arguments.consumePositionalArgument() else {
+			if let defaultValue = argument.defaultValue {
+				return .Success(defaultValue)
+			} else {
+				return .Failure(missingArgumentError(argument.usage))
+			}
+		}
+
+		var values = [T]()
+
+		if let value = T.fromString(firstValue) {
+			values.append(value)
+		} else {
+			return .Failure(argument.invalidUsageError(firstValue))
+		}
+
+		while let nextValue = arguments.consumePositionalArgument() {
+			if let value = T.fromString(nextValue) {
+				values.append(value)
+			} else {
+				return .Failure(argument.invalidUsageError(nextValue))
+			}
+		}
+
+		return .Success(values)
+
+	case .Usage:
+		return .Failure(informativeUsageError(argument))
+	}
+}

--- a/Commandant/Argument.swift
+++ b/Commandant/Argument.swift
@@ -34,7 +34,7 @@ public struct Argument<T> {
 /// Evaluates the given argument in the given mode.
 ///
 /// If parsing command line arguments, and no value was specified on the command
-/// line, the option's `defaultValue` is used.
+/// line, the argument's `defaultValue` is used.
 public func <| <T: ArgumentType, ClientError>(mode: CommandMode, argument: Argument<T>) -> Result<T, CommandantError<ClientError>> {
 	switch mode {
 	case let .Arguments(arguments):
@@ -60,7 +60,7 @@ public func <| <T: ArgumentType, ClientError>(mode: CommandMode, argument: Argum
 /// Evaluates the given argument list in the given mode.
 ///
 /// If parsing command line arguments, and no value was specified on the command
-/// line, the option's `defaultValue` is used.
+/// line, the argument's `defaultValue` is used.
 public func <| <T: ArgumentType, ClientError>(mode: CommandMode, argument: Argument<[T]>) -> Result<[T], CommandantError<ClientError>> {
 	switch mode {
 	case let .Arguments(arguments):

--- a/Commandant/ArgumentType.swift
+++ b/Commandant/ArgumentType.swift
@@ -1,0 +1,32 @@
+//
+//  ArgumentType.swift
+//  Commandant
+//
+//  Created by Syo Ikeda on 12/14/15.
+//  Copyright (c) 2015 Carthage. All rights reserved.
+//
+
+/// Represents a value that can be converted from a command-line argument.
+public protocol ArgumentType {
+	/// A human-readable name for this type.
+	static var name: String { get }
+
+	/// Attempts to parse a value from the given command-line argument.
+	static func fromString(string: String) -> Self?
+}
+
+extension Int: ArgumentType {
+	public static let name = "integer"
+
+	public static func fromString(string: String) -> Int? {
+		return Int(string)
+	}
+}
+
+extension String: ArgumentType {
+	public static let name = "string"
+
+	public static func fromString(string: String) -> String? {
+		return string
+	}
+}

--- a/Commandant/Errors.swift
+++ b/Commandant/Errors.swift
@@ -131,11 +131,7 @@ internal func informativeUsageError<T, ClientError>(keyValueExample: String, opt
 
 /// Constructs an error that describes how to use the option.
 internal func informativeUsageError<T: ArgumentType, ClientError>(option: Option<T>) -> CommandantError<ClientError> {
-	var example = ""
-
-	if let key = option.key {
-		example += "--\(key) "
-	}
+	var example = "--\(option.key) "
 
 	var valueExample = ""
 	if let defaultValue = option.defaultValue {
@@ -153,9 +149,7 @@ internal func informativeUsageError<T: ArgumentType, ClientError>(option: Option
 
 /// Constructs an error that describes how to use the given boolean option.
 internal func informativeUsageError<ClientError>(option: Option<Bool>) -> CommandantError<ClientError> {
-	precondition(option.key != nil)
-
-	let key = option.key!
+	let key = option.key
 
 	if let defaultValue = option.defaultValue {
 		return informativeUsageError((defaultValue ? "--no-\(key)" : "--\(key)"), option: option)

--- a/Commandant/Errors.swift
+++ b/Commandant/Errors.swift
@@ -53,6 +53,24 @@ internal func informativeUsageError<ClientError>(keyValueExample: String, usage:
 	})
 }
 
+/// Combines the text of the two errors, if they're both `UsageError`s.
+/// Otherwise, uses whichever one is not (biased toward the left).
+internal func combineUsageErrors<ClientError>(lhs: CommandantError<ClientError>, _ rhs: CommandantError<ClientError>) -> CommandantError<ClientError> {
+	switch (lhs, rhs) {
+	case let (.UsageError(left), .UsageError(right)):
+		let combinedDescription = "\(left)\n\n\(right)"
+		return .UsageError(description: combinedDescription)
+
+	case (.UsageError, _):
+		return rhs
+
+	case (_, .UsageError), (_, _):
+		return lhs
+	}
+}
+
+// MARK: Option
+
 /// Constructs an error that describes how to use the option, with the given
 /// example of key (and value, if applicable) usage.
 internal func informativeUsageError<T, ClientError>(keyValueExample: String, option: Option<T>) -> CommandantError<ClientError> {
@@ -95,21 +113,5 @@ internal func informativeUsageError<ClientError>(option: Option<Bool>) -> Comman
 		return informativeUsageError((defaultValue ? "--no-\(key)" : "--\(key)"), option: option)
 	} else {
 		return informativeUsageError("--(no-)\(key)", option: option)
-	}
-}
-
-/// Combines the text of the two errors, if they're both `UsageError`s.
-/// Otherwise, uses whichever one is not (biased toward the left).
-internal func combineUsageErrors<ClientError>(lhs: CommandantError<ClientError>, _ rhs: CommandantError<ClientError>) -> CommandantError<ClientError> {
-	switch (lhs, rhs) {
-	case let (.UsageError(left), .UsageError(right)):
-		let combinedDescription = "\(left)\n\n\(right)"
-		return .UsageError(description: combinedDescription)
-
-	case (.UsageError, _):
-		return rhs
-	
-	case (_, .UsageError), (_, _):
-		return lhs
 	}
 }

--- a/Commandant/Errors.swift
+++ b/Commandant/Errors.swift
@@ -69,6 +69,54 @@ internal func combineUsageErrors<ClientError>(lhs: CommandantError<ClientError>,
 	}
 }
 
+// MARK: Argument
+
+/// Constructs an error that describes how to use the argument, with the given
+/// example of value usage if applicable.
+internal func informativeUsageError<T, ClientError>(valueExample: String, argument: Argument<T>) -> CommandantError<ClientError> {
+	if argument.defaultValue != nil {
+		return informativeUsageError("[\(valueExample)]", usage: argument.usage)
+	} else {
+		return informativeUsageError(valueExample, usage: argument.usage)
+	}
+}
+
+/// Constructs an error that describes how to use the argument.
+internal func informativeUsageError<T: ArgumentType, ClientError>(argument: Argument<T>) -> CommandantError<ClientError> {
+	var example = ""
+
+	var valueExample = ""
+	if let defaultValue = argument.defaultValue {
+		valueExample = "\(defaultValue)"
+	}
+
+	if valueExample.isEmpty {
+		example += "(\(T.name))"
+	} else {
+		example += valueExample
+	}
+
+	return informativeUsageError(example, argument: argument)
+}
+
+/// Constructs an error that describes how to use the argument list.
+internal func informativeUsageError<T: ArgumentType, ClientError>(argument: Argument<[T]>) -> CommandantError<ClientError> {
+	var example = ""
+
+	var valueExample = ""
+	if let defaultValue = argument.defaultValue {
+		valueExample = "\(defaultValue)"
+	}
+
+	if valueExample.isEmpty {
+		example += "(\(T.name))"
+	} else {
+		example += valueExample
+	}
+
+	return informativeUsageError(example, argument: argument)
+}
+
 // MARK: Option
 
 /// Constructs an error that describes how to use the option, with the given

--- a/Commandant/HelpCommand.swift
+++ b/Commandant/HelpCommand.swift
@@ -69,6 +69,6 @@ private struct HelpOptions<ClientError>: OptionsType {
 
 	static func evaluate(m: CommandMode) -> Result<HelpOptions, CommandantError<ClientError>> {
 		return create
-			<*> m <| Option(defaultValue: "", usage: "the command to display help for")
+			<*> m <| Argument(defaultValue: "", usage: "the command to display help for")
 	}
 }

--- a/Commandant/Option.swift
+++ b/Commandant/Option.swift
@@ -47,12 +47,7 @@ public protocol OptionsType {
 public struct Option<T> {
 	/// The key that controls this option. For example, a key of `verbose` would
 	/// be used for a `--verbose` option.
-	///
-	/// If this is nil, this option will not have a corresponding flag, and must
-	/// be specified as a plain value at the end of the argument list.
-	///
-	/// This must be non-nil for a boolean option.
-	public let key: String?
+	public let key: String
 
 	/// The default value for this option. This is the value that will be used
 	/// if the option is never explicitly specified on the command line.
@@ -68,7 +63,7 @@ public struct Option<T> {
 	/// differently from the default).
 	public let usage: String
 
-	public init(key: String? = nil, defaultValue: T? = nil, usage: String) {
+	public init(key: String, defaultValue: T? = nil, usage: String) {
 		self.key = key
 		self.defaultValue = defaultValue
 		self.usage = usage
@@ -84,11 +79,7 @@ public struct Option<T> {
 
 extension Option: CustomStringConvertible {
 	public var description: String {
-		if let key = key {
-			return "--\(key)"
-		} else {
-			return usage
-		}
+		return "--\(key)"
 	}
 }
 
@@ -164,22 +155,18 @@ public func <| <T: ArgumentType, ClientError>(mode: CommandMode, option: Option<
 	switch mode {
 	case let .Arguments(arguments):
 		var stringValue: String?
-		if let key = option.key {
-			switch arguments.consumeValueForKey(key) {
-			case let .Success(value):
-				stringValue = value
+		switch arguments.consumeValueForKey(option.key) {
+		case let .Success(value):
+			stringValue = value
 
-			case let .Failure(error):
-				switch error {
-				case let .UsageError(description):
-					return .Failure(.UsageError(description: description))
+		case let .Failure(error):
+			switch error {
+			case let .UsageError(description):
+				return .Failure(.UsageError(description: description))
 
-				case .CommandError:
-					fatalError("CommandError should be impossible when parameterized over NoError")
-				}
+			case .CommandError:
+				fatalError("CommandError should be impossible when parameterized over NoError")
 			}
-		} else {
-			stringValue = arguments.consumePositionalArgument()
 		}
 
 		if let stringValue = stringValue {
@@ -204,11 +191,9 @@ public func <| <T: ArgumentType, ClientError>(mode: CommandMode, option: Option<
 /// If parsing command line arguments, and no value was specified on the command
 /// line, the option's `defaultValue` is used.
 public func <| <ClientError>(mode: CommandMode, option: Option<Bool>) -> Result<Bool, CommandantError<ClientError>> {
-	precondition(option.key != nil)
-
 	switch mode {
 	case let .Arguments(arguments):
-		if let value = arguments.consumeBooleanKey(option.key!) {
+		if let value = arguments.consumeBooleanKey(option.key) {
 			return .Success(value)
 		} else if let defaultValue = option.defaultValue {
 			return .Success(defaultValue)

--- a/Commandant/Option.swift
+++ b/Commandant/Option.swift
@@ -92,31 +92,6 @@ extension Option: CustomStringConvertible {
 	}
 }
 
-/// Represents a value that can be converted from a command-line argument.
-public protocol ArgumentType {
-	/// A human-readable name for this type.
-	static var name: String { get }
-
-	/// Attempts to parse a value from the given command-line argument.
-	static func fromString(string: String) -> Self?
-}
-
-extension Int: ArgumentType {
-	public static let name = "integer"
-
-	public static func fromString(string: String) -> Int? {
-		return Int(string)
-	}
-}
-
-extension String: ArgumentType {
-	public static let name = "string"
-
-	public static func fromString(string: String) -> String? {
-		return string
-	}
-}
-
 // Inspired by the Argo library:
 // https://github.com/thoughtbot/Argo
 /*

--- a/CommandantTests/OptionSpec.swift
+++ b/CommandantTests/OptionSpec.swift
@@ -110,11 +110,11 @@ struct TestOptions: OptionsType, Equatable {
 }
 
 func ==(lhs: TestOptions, rhs: TestOptions) -> Bool {
-	return lhs.intValue == rhs.intValue && lhs.stringValue == rhs.stringValue && lhs.optionalFilename == rhs.optionalFilename && lhs.requiredName == rhs.requiredName
+	return lhs.intValue == rhs.intValue && lhs.stringValue == rhs.stringValue && lhs.optionalFilename == rhs.optionalFilename && lhs.requiredName == rhs.requiredName && lhs.enabled == rhs.enabled && lhs.force == rhs.force && lhs.glob == rhs.glob
 }
 
 extension TestOptions: CustomStringConvertible {
 	var description: String {
-		return "{ intValue: \(intValue), stringValue: \(stringValue), optionalFilename: \(optionalFilename), requiredName: \(requiredName) }"
+		return "{ intValue: \(intValue), stringValue: \(stringValue), optionalFilename: \(optionalFilename), requiredName: \(requiredName), enabled: \(enabled), force: \(force), glob: \(glob) }"
 	}
 }

--- a/CommandantTests/OptionSpec.swift
+++ b/CommandantTests/OptionSpec.swift
@@ -31,43 +31,49 @@ class OptionsTypeSpec: QuickSpec {
 
 			it("should succeed without optional arguments") {
 				let value = tryArguments("required").value
-				let expected = TestOptions(intValue: 42, stringValue: "foobar", optionalFilename: "filename", requiredName: "required", enabled: false, force: false, glob: false)
+				let expected = TestOptions(intValue: 42, stringValue: "foobar", optionalFilename: "filename", requiredName: "required", enabled: false, force: false, glob: false, arguments: [])
 				expect(value).to(equal(expected))
 			}
 
 			it("should succeed with some optional arguments") {
 				let value = tryArguments("required", "--intValue", "3", "fuzzbuzz").value
-				let expected = TestOptions(intValue: 3, stringValue: "foobar", optionalFilename: "fuzzbuzz", requiredName: "required", enabled: false, force: false, glob: false)
+				let expected = TestOptions(intValue: 3, stringValue: "foobar", optionalFilename: "fuzzbuzz", requiredName: "required", enabled: false, force: false, glob: false, arguments: [])
 				expect(value).to(equal(expected))
 			}
 
 			it("should override previous optional arguments") {
 				let value = tryArguments("required", "--intValue", "3", "--stringValue", "fuzzbuzz", "--intValue", "5", "--stringValue", "bazbuzz").value
-				let expected = TestOptions(intValue: 5, stringValue: "bazbuzz", optionalFilename: "filename", requiredName: "required", enabled: false, force: false, glob: false)
+				let expected = TestOptions(intValue: 5, stringValue: "bazbuzz", optionalFilename: "filename", requiredName: "required", enabled: false, force: false, glob: false, arguments: [])
 				expect(value).to(equal(expected))
 			}
 
 			it("should enable a boolean flag") {
 				let value = tryArguments("required", "--enabled", "--intValue", "3", "fuzzbuzz").value
-				let expected = TestOptions(intValue: 3, stringValue: "foobar", optionalFilename: "fuzzbuzz", requiredName: "required", enabled: true, force: false, glob: false)
+				let expected = TestOptions(intValue: 3, stringValue: "foobar", optionalFilename: "fuzzbuzz", requiredName: "required", enabled: true, force: false, glob: false, arguments: [])
 				expect(value).to(equal(expected))
 			}
 
 			it("should re-disable a boolean flag") {
 				let value = tryArguments("required", "--enabled", "--no-enabled", "--intValue", "3", "fuzzbuzz").value
-				let expected = TestOptions(intValue: 3, stringValue: "foobar", optionalFilename: "fuzzbuzz", requiredName: "required", enabled: false, force: false, glob: false)
+				let expected = TestOptions(intValue: 3, stringValue: "foobar", optionalFilename: "fuzzbuzz", requiredName: "required", enabled: false, force: false, glob: false, arguments: [])
 				expect(value).to(equal(expected))
 			}
 
 			it("should enable multiple boolean flags") {
 				let value = tryArguments("required", "-fg").value
-				let expected = TestOptions(intValue: 42, stringValue: "foobar", optionalFilename: "filename", requiredName: "required", enabled: false, force: true, glob: true)
+				let expected = TestOptions(intValue: 42, stringValue: "foobar", optionalFilename: "filename", requiredName: "required", enabled: false, force: true, glob: true, arguments: [])
+				expect(value).to(equal(expected))
+			}
+
+			it("should consume the rest of positional arguments") {
+				let value = tryArguments("required", "optional", "value1", "value2").value
+				let expected = TestOptions(intValue: 42, stringValue: "foobar", optionalFilename: "optional", requiredName: "required", enabled: false, force: false, glob: false, arguments: [ "value1", "value2" ])
 				expect(value).to(equal(expected))
 			}
 
 			it("should treat -- as the end of valued options") {
 				let value = tryArguments("--", "--intValue").value
-				let expected = TestOptions(intValue: 42, stringValue: "foobar", optionalFilename: "filename", requiredName: "--intValue", enabled: false, force: false, glob: false)
+				let expected = TestOptions(intValue: 42, stringValue: "foobar", optionalFilename: "filename", requiredName: "--intValue", enabled: false, force: false, glob: false, arguments: [])
 				expect(value).to(equal(expected))
 			}
 		}
@@ -92,29 +98,31 @@ struct TestOptions: OptionsType, Equatable {
 	let enabled: Bool
 	let force: Bool
 	let glob: Bool
+	let arguments: [String]
 
-	static func create(a: Int)(b: String)(c: String)(d: String)(e: Bool)(f: Bool)(g: Bool) -> TestOptions {
-		return self.init(intValue: a, stringValue: b, optionalFilename: d, requiredName: c, enabled: e, force: f, glob: g)
+	static func create(a: Int)(b: String)(c: String)(d: String)(e: Bool)(f: Bool)(g: Bool)(h: [String]) -> TestOptions {
+		return self.init(intValue: a, stringValue: b, optionalFilename: d, requiredName: c, enabled: e, force: f, glob: g, arguments: h)
 	}
 
 	static func evaluate(m: CommandMode) -> Result<TestOptions, CommandantError<NoError>> {
 		return create
 			<*> m <| Option(key: "intValue", defaultValue: 42, usage: "Some integer value")
 			<*> m <| Option(key: "stringValue", defaultValue: "foobar", usage: "Some string value")
-			<*> m <| Option(usage: "A name you're required to specify")
-			<*> m <| Option(defaultValue: "filename", usage: "A filename that you can optionally specify")
+			<*> m <| Argument(usage: "A name you're required to specify")
+			<*> m <| Argument(defaultValue: "filename", usage: "A filename that you can optionally specify")
 			<*> m <| Option(key: "enabled", defaultValue: false, usage: "Whether to be enabled")
 			<*> m <| Switch(flag: "f", key: "force", usage: "Whether to force")
 			<*> m <| Switch(flag: "g", key: "glob", usage: "Whether to glob")
+			<*> m <| Argument(defaultValue: [], usage: "An argument list that consumes the rest of positional arguments")
 	}
 }
 
 func ==(lhs: TestOptions, rhs: TestOptions) -> Bool {
-	return lhs.intValue == rhs.intValue && lhs.stringValue == rhs.stringValue && lhs.optionalFilename == rhs.optionalFilename && lhs.requiredName == rhs.requiredName && lhs.enabled == rhs.enabled && lhs.force == rhs.force && lhs.glob == rhs.glob
+	return lhs.intValue == rhs.intValue && lhs.stringValue == rhs.stringValue && lhs.optionalFilename == rhs.optionalFilename && lhs.requiredName == rhs.requiredName && lhs.enabled == rhs.enabled && lhs.force == rhs.force && lhs.glob == rhs.glob && lhs.arguments == rhs.arguments
 }
 
 extension TestOptions: CustomStringConvertible {
 	var description: String {
-		return "{ intValue: \(intValue), stringValue: \(stringValue), optionalFilename: \(optionalFilename), requiredName: \(requiredName), enabled: \(enabled), force: \(force), glob: \(glob) }"
+		return "{ intValue: \(intValue), stringValue: \(stringValue), optionalFilename: \(optionalFilename), requiredName: \(requiredName), enabled: \(enabled), force: \(force), glob: \(glob), arguments: \(arguments) }"
 	}
 }


### PR DESCRIPTION
This is needed at https://github.com/Carthage/Carthage/pull/972#issuecomment-164314514.

- A positional argument is represented as `Argument` now.
- If `Argument` is tied to a property of `Array<ArgumentType>` type, that consumes the rest of positional arguments entirely.
- `Option.key` is non-optional now.