### PR TITLE
Fix crash in `help` command

### DIFF
--- a/Commandant.xcodeproj/project.pbxproj
+++ b/Commandant.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		CD2ED3411C1E6C5D0076092B /* Argument.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2ED3401C1E6C5D0076092B /* Argument.swift */; };
 		CD2ED3431C1E6D540076092B /* ArgumentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2ED3421C1E6D540076092B /* ArgumentType.swift */; };
+		CDFC88361C3C0612003AC8F8 /* CommandSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFC88351C3C0612003AC8F8 /* CommandSpec.swift */; };
 		D00CCDDF1A20717400109F8C /* Commandant.h in Headers */ = {isa = PBXBuildFile; fileRef = D00CCDDE1A20717400109F8C /* Commandant.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D00CCDE51A20717400109F8C /* Commandant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D00CCDD91A20717400109F8C /* Commandant.framework */; };
 		D00CCE241A2073DA00109F8C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D00CCE221A2073DA00109F8C /* Nimble.framework */; };
@@ -36,6 +37,7 @@
 /* Begin PBXFileReference section */
 		CD2ED3401C1E6C5D0076092B /* Argument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Argument.swift; sourceTree = "<group>"; };
 		CD2ED3421C1E6D540076092B /* ArgumentType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArgumentType.swift; sourceTree = "<group>"; };
+		CDFC88351C3C0612003AC8F8 /* CommandSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandSpec.swift; sourceTree = "<group>"; };
 		D00CCDD91A20717400109F8C /* Commandant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Commandant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D00CCDDD1A20717400109F8C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D00CCDDE1A20717400109F8C /* Commandant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Commandant.h; sourceTree = "<group>"; };
@@ -136,6 +138,7 @@
 		D00CCDE81A20717400109F8C /* CommandantTests */ = {
 			isa = PBXGroup;
 			children = (
+				CDFC88351C3C0612003AC8F8 /* CommandSpec.swift */,
 				D00CCE281A20741C00109F8C /* OptionSpec.swift */,
 				D00CCDE91A20717400109F8C /* Supporting Files */,
 			);
@@ -364,6 +367,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CDFC88361C3C0612003AC8F8 /* CommandSpec.swift in Sources */,
 				D00CCE291A20741C00109F8C /* OptionSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Commandant/Command.swift
+++ b/Commandant/Command.swift
@@ -49,12 +49,14 @@ public struct CommandWrapper<ClientError: ErrorType> {
 				return .Failure(unrecognizedArgumentsError(remainingArguments))
 			}
 
-			if let options = options.value {
+			switch options {
+			case let .Success(options):
 				return command
 					.run(options)
 					.mapError(CommandantError.CommandError)
-			} else {
-				return .Failure(options.error!)
+
+			case let .Failure(error):
+				return .Failure(error)
 			}
 		}
 		usage = { () -> CommandantError<ClientError> in

--- a/Commandant/Command.swift
+++ b/Commandant/Command.swift
@@ -36,7 +36,7 @@ public struct CommandWrapper<ClientError: ErrorType> {
 	
 	public let run: ArgumentParser -> Result<(), CommandantError<ClientError>>
 	
-	public let usage: () -> CommandantError<ClientError>
+	public let usage: () -> CommandantError<ClientError>?
 
 	/// Creates a command that wraps another.
 	private init<C: CommandType where C.ClientError == ClientError, C.Options.ClientError == ClientError>(_ command: C) {
@@ -59,8 +59,8 @@ public struct CommandWrapper<ClientError: ErrorType> {
 				return .Failure(error)
 			}
 		}
-		usage = { () -> CommandantError<ClientError> in
-			return C.Options.evaluate(.Usage).error!
+		usage = { () -> CommandantError<ClientError>? in
+			return C.Options.evaluate(.Usage).error
 		}
 	}
 }

--- a/Commandant/HelpCommand.swift
+++ b/Commandant/HelpCommand.swift
@@ -35,8 +35,10 @@ public struct HelpCommand<ClientError: ErrorType>: CommandType {
 	public func run(options: Options) -> Result<(), ClientError> {
 		if let verb = options.verb {
 			if let command = self.registry[verb] {
-				print(command.function, terminator: "\n\n")
-				print(command.usage())
+				print(command.function)
+				if let usageError = command.usage() {
+					print("\n\(usageError)")
+				}
 				return .Success(())
 			} else {
 				fputs("Unrecognized command: '\(verb)'\n", stderr)

--- a/CommandantTests/CommandSpec.swift
+++ b/CommandantTests/CommandSpec.swift
@@ -1,0 +1,38 @@
+//
+//  CommandSpec.swift
+//  Commandant
+//
+//  Created by Syo Ikeda on 1/5/16.
+//  Copyright © 2016 Carthage. All rights reserved.
+//
+
+import Commandant
+import Nimble
+import Quick
+import Result
+
+class CommandWrapperSpec: QuickSpec {
+	override func spec() {
+		describe("CommandWrapper.usage") {
+			it("should not crash for a command with NoOptions") {
+				let command = NoOptionsCommand()
+
+				let registry = CommandRegistry<CommandantError<()>>()
+				registry.register(command)
+
+				let wrapper = registry[command.verb]
+				expect(wrapper).notTo(beNil())
+				expect(wrapper?.usage()).to(beNil())
+			}
+		}
+	}
+}
+
+struct NoOptionsCommand: CommandType {
+	var verb: String { return "verb" }
+	var function: String { return "function" }
+
+	func run(options: NoOptions<CommandantError<()>>) -> Result<(), CommandantError<()>> {
+		return .Success()
+	}
+}


### PR DESCRIPTION
This avoids force unwrapping of error in `usage` closure. Some options may return `.Success` case for `CommandMode.Usage` (e.g. `NoOptions`).

Sould fix https://github.com/realm/SwiftLint/pull/312#issuecomment-168558053.