### PR TITLE
Expose a public initializer to NoOptions so that tests can be written for commands that take NoOptions

### DIFF
--- a/Sources/Commandant/Option.swift
+++ b/Sources/Commandant/Option.swift
@@ -45,7 +45,7 @@ public protocol OptionsType {
 
 /// An `OptionsType` that has no options.
 public struct NoOptions<ClientError: ErrorType>: OptionsType {
-	private init() {}
+	public init() {}
 	
 	public static func evaluate(m: CommandMode) -> Result<NoOptions, CommandantError<ClientError>> {
 		return .Success(NoOptions())


### PR DESCRIPTION
Why was this not exposed earlier?