### PR TITLE
Swift 2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
 language: objective-c
-osx_image: xcode7.3
 script: placeholder # workaround for https://github.com/travis-ci/travis-ci/issues/4681
 matrix:
   exclude:
     - script: placeholder # workaround for https://github.com/travis-ci/travis-ci/issues/4681
   include:
     - script: script/cibuild
+      osx_image: xcode7.2
+      env: JOB=Xcode
+      xcode_workspace: Commandant.xcworkspace
+      xcode_scheme: Commandant
+    - script: script/cibuild
+      osx_image: xcode7.3
       env: JOB=Xcode
       xcode_workspace: Commandant.xcworkspace
       xcode_scheme: Commandant
     - script: swift build
+      osx_image: xcode7.3
       env: JOB=SPM
       before_install:
         - export SWIFT_VERSION=swift-DEVELOPMENT-SNAPSHOT-2016-03-01-a

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - script: swift build
       env: JOB=SPM
       before_install:
-        - export SWIFT_VERSION=swift-DEVELOPMENT-SNAPSHOT-2016-01-25-a
+        - export SWIFT_VERSION=swift-DEVELOPMENT-SNAPSHOT-2016-03-01-a
         - curl https://swift.org/builds/development/xcode/$SWIFT_VERSION/$SWIFT_VERSION-osx.pkg -o swift.pkg
         - sudo installer -pkg swift.pkg -target /
         - export PATH="/Library/Developer/Toolchains/$SWIFT_VERSION.xctoolchain/usr/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.2
+osx_image: xcode7.3
 script: placeholder # workaround for https://github.com/travis-ci/travis-ci/issues/4681
 matrix:
   exclude:

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
-github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"
+github "jspahrsummers/xcconfigs" ~> 0.9
 github "Quick/Quick" ~> 0.9
 github "Quick/Nimble" ~> 3.2

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"
 github "Quick/Quick" ~> 0.9
-github "Quick/Nimble" ~> 3.1
+github "Quick/Nimble" ~> 3.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "Quick/Nimble" "v3.2.0"
 github "Quick/Quick" "v0.9.1"
 github "antitypical/Result" "1.0.2"
-github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"
+github "jspahrsummers/xcconfigs" "0.9"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v3.1.0"
+github "Quick/Nimble" "v3.2.0"
 github "Quick/Quick" "v0.9.1"
 github "antitypical/Result" "1.0.2"
 github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"

--- a/Commandant.xcodeproj/project.pbxproj
+++ b/Commandant.xcodeproj/project.pbxproj
@@ -390,7 +390,6 @@
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -403,7 +402,6 @@
 			baseConfigurationReference = D00CCDFC1A20719500109F8C /* Release.xcconfig */;
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 1;
-				GCC_NO_COMMON_BLOCKS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -476,7 +474,6 @@
 			baseConfigurationReference = D00CCDFB1A20719500109F8C /* Profile.xcconfig */;
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 1;
-				GCC_NO_COMMON_BLOCKS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -518,7 +515,6 @@
 			baseConfigurationReference = D00CCDFD1A20719500109F8C /* Test.xcconfig */;
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 1;
-				GCC_NO_COMMON_BLOCKS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Sources/Commandant/Command.swift
+++ b/Sources/Commandant/Command.swift
@@ -13,9 +13,9 @@ import Result
 public protocol CommandType {
 	
 	/// The command's options type.
-	typealias Options: OptionsType
+	associatedtype Options: OptionsType
 
-	typealias ClientError: ErrorType = Options.ClientError
+	associatedtype ClientError: ErrorType = Options.ClientError
 	
 	/// The action that users should specify to use this subcommand (e.g.,
 	/// `help`).

--- a/Sources/Commandant/Command.swift
+++ b/Sources/Commandant/Command.swift
@@ -13,9 +13,9 @@ import Result
 public protocol CommandType {
 	
 	/// The command's options type.
-	associatedtype Options: OptionsType
+	typealias Options: OptionsType
 
-	associatedtype ClientError: ErrorType = Options.ClientError
+	typealias ClientError: ErrorType = Options.ClientError
 	
 	/// The action that users should specify to use this subcommand (e.g.,
 	/// `help`).

--- a/Sources/Commandant/Option.swift
+++ b/Sources/Commandant/Option.swift
@@ -35,7 +35,7 @@ import Result
 ///			}
 ///		}
 public protocol OptionsType {
-	associatedtype ClientError: ErrorType
+	typealias ClientError: ErrorType
 
 	/// Evaluates this set of options in the given mode.
 	///

--- a/Sources/Commandant/Option.swift
+++ b/Sources/Commandant/Option.swift
@@ -35,7 +35,7 @@ import Result
 ///			}
 ///		}
 public protocol OptionsType {
-	typealias ClientError: ErrorType
+	associatedtype ClientError: ErrorType
 
 	/// Evaluates this set of options in the given mode.
 	///

--- a/Tests/OptionSpec.swift
+++ b/Tests/OptionSpec.swift
@@ -100,8 +100,10 @@ struct TestOptions: OptionsType, Equatable {
 
 	typealias ClientError = NoError
 
-	static func create(a: Int)(b: String)(c: String)(d: String)(e: Bool)(f: Bool)(g: Bool)(h: [String]) -> TestOptions {
-		return self.init(intValue: a, stringValue: b, optionalFilename: d, requiredName: c, enabled: e, force: f, glob: g, arguments: h)
+	static func create(a: Int) -> String -> String -> String -> Bool -> Bool -> Bool -> [String] -> TestOptions {
+		return { b in { c in { d in { e in { f in { g in { h in
+			return self.init(intValue: a, stringValue: b, optionalFilename: d, requiredName: c, enabled: e, force: f, glob: g, arguments: h)
+		} } } } } } }
 	}
 
 	static func evaluate(m: CommandMode) -> Result<TestOptions, CommandantError<NoError>> {


### PR DESCRIPTION
~~This is another breaking change because of the `associatedtype` usage.~~

Updated `Nimble` to be built with Xcode 7.3.