### PR TITLE
Add missing `@available`s to enums

### DIFF
--- a/Sources/Commandant/Command.swift
+++ b/Sources/Commandant/Command.swift
@@ -217,6 +217,17 @@ extension CommandRegistry {
 @available(*, unavailable, renamed: "CommandProtocol")
 public typealias CommandType = CommandProtocol
 
+extension CommandMode {
+	@available(*, unavailable, renamed: "arguments(_:)")
+	public static func Arguments(_ parser: ArgumentParser) -> CommandMode {
+		return .arguments(parser)
+	}
+	@available(*, unavailable, renamed: "usage")
+	public static var Usage: CommandMode {
+		return .usage
+	}
+}
+
 extension CommandRegistry {
 	@available(*, unavailable, renamed: "run(command:arguments:)")
 	public func runCommand(_ verb: String, arguments: [String]) -> Result<(), CommandantError<ClientError>>? {

--- a/Sources/Commandant/Errors.swift
+++ b/Sources/Commandant/Errors.swift
@@ -146,3 +146,15 @@ internal func informativeUsageError<ClientError>(_ option: Option<Bool>) -> Comm
 // MARK: - migration support
 @available(*, unavailable, message: "Use ErrorProtocol instead of ClientErrorType")
 public typealias ClientErrorType = Error
+
+extension CommandantError {
+	@available(*, unavailable, renamed: "usageError(description:)")
+	public static func UsageError(description: String) -> CommandantError {
+		return .usageError(description: description)
+	}
+
+	@available(*, unavailable, renamed: "commandError(_:)")
+	public static func CommandError(_ error: ClientError) -> CommandantError {
+		return .commandError(error)
+	}
+}


### PR DESCRIPTION
This will provide better migration support to 0.11.x on Xcode.