### PR TITLE
remove Nimble from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,6 @@ let package = Package(
         #else
             return [
                 .Package(url: "https://github.com/antitypical/Result.git", majorVersion: 3, minor: 0),
-                .Package(url: "https://github.com/Quick/Nimble", majorVersion: 5, minor: 0),
                 .Package(url: "https://github.com/Quick/Quick", majorVersion: 0, minor: 10),
             ]
         #endif


### PR DESCRIPTION
it's implicitly included when Quick is pulled in. Resolves #79.