### PR TITLE
fix travis deploy by specifying to run when JOB=Xcode8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ deploy:
   on:
     repo: Carthage/Commandant
     tags: true
-    condition: $JOB = Xcode7.3
+    condition: $JOB = Xcode8


### PR DESCRIPTION
This is likely why https://github.com/Carthage/Commandant/releases/tag/0.11.2 (and 0.11.1) didn't get `Commandant.framework.zip` automatically attached.