### PR TITLE
[SwiftPM] Remove test dependencies from `Package.swift`

### DIFF
--- a/.Package.test.swift
+++ b/.Package.test.swift
@@ -4,5 +4,7 @@ let package = Package(
     name: "Commandant",
     dependencies: [
         .Package(url: "https://github.com/antitypical/Result.git", majorVersion: 3, minor: 0),
+        .Package(url: "https://github.com/Quick/Nimble", majorVersion: 5),
+        .Package(url: "https://github.com/Quick/Quick", majorVersion: 0, minor: 10),
     ]
 )

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,10 @@ matrix:
       osx_image: xcode8
       language: objective-c
       env: JOB=SPM
-    - script: swift build && swift test
+    - script:
+        - mv .Package.test.swift Package.swift
+        - swift build
+        - swift test
       env: JOB=Linux
       sudo: required
       dist: trusty


### PR DESCRIPTION
We still run `swift test` on CI using separated `.Package.test.swift`.

Should fix #82.
