### PR TITLE
Bump Result version to 3.1.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "antitypical/Result" ~> 3.0
+github "antitypical/Result" ~> 3.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "Quick/Nimble" "v5.0.0"
 github "Quick/Quick" "v0.10.0"
-github "antitypical/Result" "3.0.0"
+github "antitypical/Result" "3.1.0"
 github "jspahrsummers/xcconfigs" "0.9"

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,6 @@ import PackageDescription
 let package = Package(
     name: "Commandant",
     dependencies: [
-        .Package(url: "https://github.com/antitypical/Result.git", majorVersion: 3),
+        .Package(url: "https://github.com/antitypical/Result.git", majorVersion: 3, minor: 1),
     ]
 )


### PR DESCRIPTION
Just update Result to 3.1.0.

Ref: https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Cartfile#L1