### PR TITLE
Fix switch keys being ignored when a Switch contains a flag

### DIFF
--- a/Sources/Commandant/Switch.swift
+++ b/Sources/Commandant/Switch.swift
@@ -53,7 +53,8 @@ public func <| <ClientError> (mode: CommandMode, option: Switch) -> Result<Bool,
 	switch mode {
 	case let .arguments(arguments):
 		var enabled = arguments.consume(key: option.key)
-		if let flag = option.flag {
+
+		if let flag = option.flag, !enabled {
 			enabled = arguments.consumeBoolean(flag: flag)
 		}
 		return .success(enabled)

--- a/Tests/CommandantTests/OptionSpec.swift
+++ b/Tests/CommandantTests/OptionSpec.swift
@@ -87,8 +87,26 @@ class OptionsProtocolSpec: QuickSpec {
 				expect(value).to(equal(expected))
 			}
 
-			it("should enable multiple boolean flags") {
+			it("should enable a boolean flag if a single Switch flag is passed") {
+				let value = tryArguments("required", "-f").value
+				let expected = TestOptions(intValue: 42, stringValue: "foobar", stringsArray: [], optionalStringsArray: nil, optionalStringValue: nil, optionalFilename: "filename", requiredName: "required", enabled: false, force: true, glob: false, arguments: [])
+				expect(value).to(equal(expected))
+			}
+
+			it("should enable multiple boolean flags if multiple grouped Switch flags are passed") {
 				let value = tryArguments("required", "-fg").value
+				let expected = TestOptions(intValue: 42, stringValue: "foobar", stringsArray: [], optionalStringsArray: nil, optionalStringValue: nil, optionalFilename: "filename", requiredName: "required", enabled: false, force: true, glob: true, arguments: [])
+				expect(value).to(equal(expected))
+			}
+
+			it("should enable a boolean flag if a single Switch key is passed") {
+				let value = tryArguments("required", "--force").value
+				let expected = TestOptions(intValue: 42, stringValue: "foobar", stringsArray: [], optionalStringsArray: nil, optionalStringValue: nil, optionalFilename: "filename", requiredName: "required", enabled: false, force: true, glob: false, arguments: [])
+				expect(value).to(equal(expected))
+			}
+
+			it("should enable multiple boolean flags if multiple Switch keys are passed") {
+				let value = tryArguments("required", "--force", "--glob").value
 				let expected = TestOptions(intValue: 42, stringValue: "foobar", stringsArray: [], optionalStringsArray: nil, optionalStringValue: nil, optionalFilename: "filename", requiredName: "required", enabled: false, force: true, glob: true, arguments: [])
 				expect(value).to(equal(expected))
 			}


### PR DESCRIPTION
See #95 

Added 3 tests - one for existing behavior, and 2 new tests for the bug I refer to.