### PR TITLE
use default command if options are present

### DIFF
--- a/Sources/Commandant/Command.swift
+++ b/Sources/Commandant/Command.swift
@@ -158,12 +158,10 @@ extension CommandRegistry {
 
 		// use the default verb even if we have other arguments
 		var verb = defaultVerb
-		if let argument = arguments.first {
-			if argument.hasPrefix("-") == false {
-				verb = argument
-				// Remove the command name.
-				arguments.remove(at: 0)
-			}
+		if let argument = arguments.first, !argument.hasPrefix("-") {
+			verb = argument
+			// Remove the command name.
+			arguments.remove(at: 0)
 		}
 		
 		switch run(command: verb, arguments: arguments) {

--- a/Sources/Commandant/Command.swift
+++ b/Sources/Commandant/Command.swift
@@ -156,12 +156,16 @@ extension CommandRegistry {
 		// Extract the executable name.
 		let executableName = arguments.remove(at: 0)
 
-		let verb = arguments.first ?? defaultVerb
-		if arguments.count > 0 {
-			// Remove the command name.
-			arguments.remove(at: 0)
+		// use the default verb even if we have other arguments
+		var verb = defaultVerb
+		if let argument = arguments.first {
+			if argument.hasPrefix("-") == false {
+				verb = argument
+				// Remove the command name.
+				arguments.remove(at: 0)
+			}
 		}
-
+		
 		switch run(command: verb, arguments: arguments) {
 		case .success?:
 			exit(EXIT_SUCCESS)


### PR DESCRIPTION
I ran into an issue with a project that uses *Commandant* where the default verb is not used if if any options/arguments are present.

For example:

```
swiftlint lint --path . // runs lint command ok
swiftlint --path . // fails since the --path argument prevents the default command from being used
```

This can also be seen with carthage as well:

```
carthage // run default command: help
carthage help --help // fails with: Unrecognized arguments: --help
carthage --use-ssh // fails with: Unrecognized command: '--use-ssh'. See `carthage help`.
```

The argument should not overwrite the default command and this PR addresses that issue.

Let me know if you have any questions or comments. Thanks!
