### PR TITLE
Remove use of deprecated  `characters` view on `String`

### DIFF
--- a/Sources/Commandant/ArgumentParser.swift
+++ b/Sources/Commandant/ArgumentParser.swift
@@ -68,7 +68,7 @@ public final class ArgumentParser {
 		rawArguments.append(contentsOf: options.map { arg in
 			if arg.hasPrefix("-") {
 				// Do we have `--{key}` or `-{flags}`.
-				let opt = arg.characters.dropFirst()
+				let opt = arg.dropFirst()
 				if opt.first == "-" {
 					return .key(String(opt.dropFirst()))
 				} else {

--- a/Sources/Commandant/HelpCommand.swift
+++ b/Sources/Commandant/HelpCommand.swift
@@ -47,10 +47,10 @@ public struct HelpCommand<ClientError: Error>: CommandProtocol {
 
 		print("Available commands:\n")
 
-		let maxVerbLength = self.registry.commands.map { $0.verb.characters.count }.max() ?? 0
+		let maxVerbLength = self.registry.commands.map { $0.verb.count }.max() ?? 0
 
 		for command in self.registry.commands {
-			let padding = repeatElement(Character(" "), count: maxVerbLength - command.verb.characters.count)
+			let padding = repeatElement(Character(" "), count: maxVerbLength - command.verb.count)
 			print("   \(command.verb)\(String(padding))   \(command.function)")
 		}
 


### PR DESCRIPTION
Just a little straightforward weeding here. The `characters` view on `String` was deprecated in Swift 3.2. This PR removes any uses of it. 