### PR TITLE
Release 0.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,10 +63,10 @@ matrix:
         - JOB=Linux
         - SWIFT_VESION=4.2.3
     - <<: *swiftpm_linux
-      name: Linux / Swift 5.0 Development
+      name: Linux / Swift 5.0
       env:
         - JOB=Linux
-        - SWIFT_VERSION=5.0-DEVELOPMENT-SNAPSHOT-2019-02-28-a
+        - SWIFT_VERSION=5.0
 
 notifications:
   email: false

--- a/Commandant.podspec
+++ b/Commandant.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "Commandant"
-  s.version      = "0.15.0"
+  s.version      = "0.16.0"
   s.summary      = "Type-safe command line argument handling"
   s.description  = <<-DESC
 Commandant is a Swift framework for parsing command-line arguments, inspired by Argo

--- a/Sources/Commandant/Info.plist
+++ b/Sources/Commandant/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.15.0</string>
+	<string>0.16.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/CommandantTests/Info.plist
+++ b/Tests/CommandantTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.15.0</string>
+	<string>0.16.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Making one last release supporting Swift ~4.1~ 4.2 & 5.0 before requiring Swift 5.0 with #146.