### PR TITLE
💥 Command Aliases

### DIFF
--- a/Sources/Commandant/Command.swift
+++ b/Sources/Commandant/Command.swift
@@ -20,6 +20,9 @@ public protocol CommandProtocol {
 	/// `help`).
 	var verb: String { get }
 
+	/// Optional list of additional verbs which can be used to invoke this command.
+	var aliases: [String] { get }
+
 	/// A human-readable, high-level description of what this command is used
 	/// for.
 	var function: String { get }
@@ -96,6 +99,10 @@ public final class CommandRegistry<ClientError: Error> {
 	{
 		for command in commands {
 			commandsByVerb[command.verb] = CommandWrapper(command)
+			// Register command for each additional alias
+			for alias in command.aliases {
+				commandsByVerb[alias] = CommandWrapper(command)
+			}
 		}
 		return self
 	}

--- a/Sources/Commandant/HelpCommand.swift
+++ b/Sources/Commandant/HelpCommand.swift
@@ -18,9 +18,11 @@ import Foundation
 /// 	let helpCommand = HelpCommand(registry: commands)
 /// 	commands.register(helpCommand)
 public struct HelpCommand<ClientError: Error>: CommandProtocol {
+
 	public typealias Options = HelpOptions<ClientError>
 
 	public let verb = "help"
+	public let aliases: [String] = []
 	public let function: String
 
 	private let registry: CommandRegistry<ClientError>


### PR DESCRIPTION
Implements #153.

Opening this PR as a draft for discussion. I've got a simple/dumb implementation of aliases working in mas and you can see the behavior below. The `install` command was given an alias of `i`, but the `help` output lists the `install` command twice.

```
Available commands:

   account     Prints the primary account Apple ID
   help        Display general or command-specific help
   home        Opens MAS Preview app page in a browser
   info        Display app information from the Mac App Store
   install     Install from the Mac App Store
   install     Install from the Mac App Store
   ...

↪ sudo mas uninstall 803453959
Password:
==> App moved to trash: /private/var/root/.Trash/Slack 20-31-11-388.app

↪ mas i 803453959
==> Downloading Slack
#####################################################------- 88.0% Installing
```

This was achieved by:

1. Adding `CommandProtocol.aliases`
1. Registering commands again, once for each alias name

Modifying the `CommandProtocol` is a breaking change and each user of this library would need to add the `alias` property to every command, even if the command has no aliases. The 2nd item causes the command duplication but could be improved by extending the idea of an alias into the registry and auto-generating the help description with something like:

```
Available commands:

   install     Install from the Mac App Store
   i     Alias for install
```

Perhaps a better approach is to register aliases differently instead of modifying the model. Going to think some more about this but welcome any feedback or suggestions.