### PR TITLE
🛠 Enable Swift Module Stability

### DIFF
--- a/Commandant.xcodeproj/project.pbxproj
+++ b/Commandant.xcodeproj/project.pbxproj
@@ -463,6 +463,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F88F258F24F34E9700EC60D5 /* macOS-Framework.xcconfig */;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -472,6 +473,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.carthage.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -480,6 +482,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F88F258F24F34E9700EC60D5 /* macOS-Framework.xcconfig */;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -489,6 +492,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.carthage.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = NO;
 			};
 			name = Release;
 		};
@@ -546,6 +550,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F88F258F24F34E9700EC60D5 /* macOS-Framework.xcconfig */;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -555,6 +560,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.carthage.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = NO;
 			};
 			name = Profile;
 		};
@@ -597,6 +603,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F88F258F24F34E9700EC60D5 /* macOS-Framework.xcconfig */;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -606,6 +613,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.carthage.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Test;


### PR DESCRIPTION
This PR enables [Module Stability](https://www.donnywals.com/what-is-module-stability-in-swift-and-why-should-you-care/) for Commandant so that switching Xcode versions doesn't require rebuilding the framework.

Example of building Commandant using Xcode 11.6, then using in Xcode 12 beta 6:
<img width="1069" alt="Screen Shot 2020-09-06 at 1 44 47 PM" src="https://user-images.githubusercontent.com/28851/92334211-2eff8d00-f049-11ea-8df7-4cf61db2563d.png">

## Framework contents without Module Stability

<img width="1046" alt="Screen Shot 2020-09-06 at 12 27 56 PM" src="https://user-images.githubusercontent.com/28851/92334240-62dab280-f049-11ea-9699-9aca01bdcde3.png">

## Build Settings


- `BUILD_LIBRARY_FOR_DISTRIBUTION = YES`
- `SKIP_INSTALL = NO`

## Framework contents with Module Stability

The new `.swiftinterface` files are evidence that module stability is enabled. I believe the format of the `.swiftmodule` files are slightly different (file sizes differ), but looking for the new file is the easiest way to tell.

<img width="1046" alt="Screen Shot 2020-09-06 at 12 28 35 PM" src="https://user-images.githubusercontent.com/28851/92334251-72f29200-f049-11ea-90ba-68d016d51867.png">
